### PR TITLE
refactor(household): extract dialogs and menus into components

### DIFF
--- a/src/app/features/household/CreateHouseholdDialog.test.tsx
+++ b/src/app/features/household/CreateHouseholdDialog.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import TranslationsWrapper from '../../../test-util/TranslationsWrapper';
+import CreateHouseholdDialog from './CreateHouseholdDialog';
+
+describe('CreateHouseholdDialog', () => {
+  const defaultProps = {
+    isCreating: false,
+    onClose: vi.fn(),
+    onCreate: vi.fn(),
+    open: true,
+  };
+
+  const renderDialog = (props = {}) => {
+    return render(
+      <TranslationsWrapper>
+        <CreateHouseholdDialog {...defaultProps} {...props} />
+      </TranslationsWrapper>,
+    );
+  };
+
+  it('renders the dialog when open', () => {
+    renderDialog();
+    expect(screen.getByRole('heading', { name: /create new household/i })).toBeVisible();
+  });
+
+  it('calls onClose when cancel is clicked', () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('validates that household name is required', async () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(await screen.findByText(/required/i)).toBeVisible();
+    expect(defaultProps.onCreate).not.toHaveBeenCalled();
+  });
+
+  it('validates that household name cannot exceed 20 characters', async () => {
+    renderDialog();
+    const nameInput = screen.getByLabelText(/household name/i);
+    fireEvent.change(nameInput, { target: { value: 'This name is definitely longer than twenty characters' } });
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(await screen.findByText(/at most 20 characters/i)).toBeVisible();
+    expect(defaultProps.onCreate).not.toHaveBeenCalled();
+  });
+
+  it('validates email addresses format', async () => {
+    renderDialog();
+    fireEvent.change(screen.getByLabelText(/household name/i), { target: { value: 'My House' } });
+    fireEvent.change(screen.getByLabelText(/invitations/i), { target: { value: 'invalid-email' } });
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(await screen.findByText(/must be a valid email address/i)).toBeVisible();
+    expect(defaultProps.onCreate).not.toHaveBeenCalled();
+  });
+
+  it('calls onCreate with correct arguments when form is valid', async () => {
+    renderDialog();
+    fireEvent.change(screen.getByLabelText(/household name/i), { target: { value: 'My House' } });
+    fireEvent.change(screen.getByLabelText(/invitations/i), {
+      target: { value: 'test@example.com, test2@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    expect(defaultProps.onCreate).toHaveBeenCalledWith('My House', ['test@example.com', 'test2@example.com']);
+  });
+
+  it('shows loading state and disables inputs when isCreating is true', () => {
+    renderDialog({ isCreating: true });
+    expect(screen.getByRole('progressbar')).toBeVisible();
+    expect(screen.getByLabelText(/household name/i)).toBeDisabled();
+    expect(screen.getByLabelText(/invitations/i)).toBeDisabled();
+  });
+
+  it('shows conflict error when onCreate throws 409', async () => {
+    const onCreate = vi.fn().mockRejectedValue({ status: 409 });
+    renderDialog({ onCreate });
+
+    fireEvent.change(screen.getByLabelText(/household name/i), { target: { value: 'Existing House' } });
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    expect(await screen.findByText(/already exists/i)).toBeVisible();
+  });
+
+  it('shows generic error when onCreate throws other error', async () => {
+    const onCreate = vi.fn().mockRejectedValue(new Error('Random error'));
+    renderDialog({ onCreate });
+
+    fireEvent.change(screen.getByLabelText(/household name/i), { target: { value: 'New House' } });
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    expect(await screen.findByText(/failed to create household/i)).toBeVisible();
+  });
+});

--- a/src/app/features/household/CreateHouseholdDialog.tsx
+++ b/src/app/features/household/CreateHouseholdDialog.tsx
@@ -1,0 +1,120 @@
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import TextField from '@mui/material/TextField';
+import { type SubmitEvent, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface CreateHouseholdDialogProps {
+  isCreating: boolean;
+  onClose: () => void;
+  onCreate: (name: string, emails: string[]) => Promise<void>;
+  open: boolean;
+}
+
+export default function CreateHouseholdDialog({ open, onClose, onCreate, isCreating }: CreateHouseholdDialogProps) {
+  const { t } = useTranslation();
+  const [newHouseholdName, setNewHouseholdName] = useState('');
+  const [invitationEmails, setInvitationEmails] = useState('');
+  const [nameError, setNameError] = useState('');
+  const [invitationsError, setInvitationsError] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setNewHouseholdName('');
+      setInvitationEmails('');
+      setNameError('');
+      setInvitationsError('');
+    }
+  }, [open]);
+
+  const validateEmail = (email: string) => {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  };
+
+  const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setNameError('');
+    setInvitationsError('');
+
+    let hasError = false;
+
+    if (!newHouseholdName) {
+      setNameError(t('validation.required-field'));
+      hasError = true;
+    } else if (newHouseholdName.length > 20) {
+      setNameError(t('validation.max-length', { count: 20 }));
+      hasError = true;
+    }
+
+    const emailList = invitationEmails
+      .split(',')
+      .map((e) => e.trim())
+      .filter((e) => e !== '');
+    const invalidEmails = emailList.filter((e) => !validateEmail(e));
+
+    if (invalidEmails.length > 0) {
+      setInvitationsError(t('validation.email'));
+      hasError = true;
+    }
+
+    if (hasError) {
+      return;
+    }
+
+    try {
+      await onCreate(newHouseholdName, emailList);
+    } catch (error) {
+      if (error && typeof error === 'object' && 'status' in error && error.status === 409) {
+        setNameError(t('household.create.error.conflict'));
+      } else {
+        setNameError(t('household.create.error.generic'));
+      }
+    }
+  };
+
+  return (
+    <Dialog fullWidth maxWidth="xs" onClose={onClose} open={open}>
+      <form noValidate onSubmit={handleSubmit}>
+        <DialogTitle>{t('household.create.dialog-title')}</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            disabled={isCreating}
+            error={!!nameError}
+            fullWidth
+            helperText={nameError}
+            label={t('household.create.name-label')}
+            margin="dense"
+            onChange={(e) => setNewHouseholdName(e.target.value)}
+            required
+            slotProps={{ htmlInput: { maxLength: 20 } }}
+            value={newHouseholdName}
+            variant="outlined"
+          />
+          <TextField
+            disabled={isCreating}
+            error={!!invitationsError}
+            fullWidth
+            helperText={invitationsError}
+            label={t('household.create.invitations-label')}
+            margin="dense"
+            onChange={(e) => setInvitationEmails(e.target.value)}
+            placeholder="email1@example.com, email2@example.com"
+            value={invitationEmails}
+            variant="outlined"
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>{t('household.create.cancel')}</Button>
+          <Button disabled={isCreating} type="submit" variant="contained">
+            {isCreating ? <CircularProgress size={24} /> : t('household.create.submit')}
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}

--- a/src/app/features/household/HouseholdSelector.tsx
+++ b/src/app/features/household/HouseholdSelector.tsx
@@ -1,30 +1,13 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import AddIcon from '@mui/icons-material/Add';
-import CheckIcon from '@mui/icons-material/Check';
-import CloseIcon from '@mui/icons-material/Close';
 import DeleteIcon from '@mui/icons-material/Delete';
-import EmailIcon from '@mui/icons-material/Email';
 import HouseIcon from '@mui/icons-material/House';
-import type { SelectChangeEvent } from '@mui/material';
-import Badge from '@mui/material/Badge';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
 import IconButton from '@mui/material/IconButton';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemText from '@mui/material/ListItemText';
-import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
+import type { SelectChangeEvent } from '@mui/material/Select';
 import Select from '@mui/material/Select';
-import Stack from '@mui/material/Stack';
-import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
-import { type MouseEvent, type SubmitEvent, useEffect, useId, useState } from 'react';
+import { type MouseEvent, useEffect, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppDispatch, useAppSelector } from '../../hooks';
 import {
@@ -37,7 +20,9 @@ import {
   useGetInvitationsQuery,
   useRejectInvitationMutation,
 } from '../../services/invitations';
+import CreateHouseholdDialog from './CreateHouseholdDialog';
 import { selectHousehold, selectSelectedHouseholdId } from './householdSlice';
+import InvitationsMenu from './InvitationsMenu';
 
 export default function HouseholdSelector() {
   const { t } = useTranslation();
@@ -59,16 +44,8 @@ export default function HouseholdSelector() {
   const isInvitationProcessing = isAccepting || isRejecting;
 
   const sortedHouseholds = households ? [...households].sort((a, b) => a.name.localeCompare(b.name)) : [];
-  const sortedInvitations = invitations
-    ? [...invitations].sort((a, b) => new Date(b.invited_at).getTime() - new Date(a.invited_at).getTime())
-    : [];
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [invitationsAnchorEl, setInvitationsAnchorEl] = useState<null | HTMLElement>(null);
-  const [newHouseholdName, setNewHouseholdName] = useState('');
-  const [invitationEmails, setInvitationEmails] = useState('');
-  const [nameError, setNameError] = useState('');
-  const [invitationsError, setInvitationsError] = useState('');
 
   useEffect(() => {
     if (localStorageKey && selectedHouseholdId !== null) {
@@ -101,10 +78,6 @@ export default function HouseholdSelector() {
 
   const handleOpenDialog = () => {
     setIsDialogOpen(true);
-    setNewHouseholdName('');
-    setInvitationEmails('');
-    setNameError('');
-    setInvitationsError('');
   };
 
   const handleCloseDialog = () => {
@@ -119,54 +92,13 @@ export default function HouseholdSelector() {
     dispatch(selectHousehold(Number(event.target.value)));
   };
 
-  const validateEmail = (email: string) => {
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
-  };
-
-  const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setNameError('');
-    setInvitationsError('');
-
-    let hasError = false;
-
-    if (!newHouseholdName) {
-      setNameError(t('validation.required-field'));
-      hasError = true;
-    } else if (newHouseholdName.length > 20) {
-      setNameError(t('validation.max-length', { count: 20 }));
-      hasError = true;
-    }
-
-    const emailList = invitationEmails
-      .split(',')
-      .map((e) => e.trim())
-      .filter((e) => e !== '');
-    const invalidEmails = emailList.filter((e) => !validateEmail(e));
-
-    if (invalidEmails.length > 0) {
-      setInvitationsError(t('validation.email'));
-      hasError = true;
-    }
-
-    if (hasError) {
-      return;
-    }
-
-    try {
-      const result = await createHousehold({
-        invitations: emailList.length > 0 ? emailList : undefined,
-        name: newHouseholdName,
-      }).unwrap();
-      dispatch(selectHousehold(result.id));
-      handleCloseDialog();
-    } catch (error) {
-      if (error && typeof error === 'object' && 'status' in error && error.status === 409) {
-        setNameError(t('household.create.error.conflict'));
-      } else {
-        setNameError(t('household.create.error.generic'));
-      }
-    }
+  const handleCreate = async (name: string, emails: string[]) => {
+    const result = await createHousehold({
+      invitations: emails.length > 0 ? emails : undefined,
+      name,
+    }).unwrap();
+    dispatch(selectHousehold(result.id));
+    handleCloseDialog();
   };
 
   const handleDelete = async (event: MouseEvent, householdId: number) => {
@@ -177,25 +109,13 @@ export default function HouseholdSelector() {
     }
   };
 
-  const handleInvitationsClick = (event: MouseEvent<HTMLElement>) => {
-    setInvitationsAnchorEl(event.currentTarget);
-  };
-
-  const handleInvitationsClose = () => {
-    setInvitationsAnchorEl(null);
-  };
-
   const handleAccept = async (invitationId: number) => {
     const newHousehold = await acceptInvitation(invitationId).unwrap();
     dispatch(selectHousehold(newHousehold.id));
-    handleInvitationsClose();
   };
 
   const handleReject = async (invitationId: number) => {
     await rejectInvitation(invitationId).unwrap();
-    if (sortedInvitations.length === 1) {
-      handleInvitationsClose();
-    }
   };
 
   return (
@@ -305,103 +225,23 @@ export default function HouseholdSelector() {
         </>
       )}
 
-      {sortedInvitations.length > 0 && (
-        <>
-          <IconButton
-            aria-label={t('household.invitations.title')}
-            color="inherit"
-            onClick={handleInvitationsClick}
-            sx={{ ml: 1 }}
-          >
-            <Badge badgeContent={sortedInvitations.length} color="error">
-              <EmailIcon />
-            </Badge>
-          </IconButton>
-          <Menu anchorEl={invitationsAnchorEl} onClose={handleInvitationsClose} open={Boolean(invitationsAnchorEl)}>
-            <Typography sx={{ px: 2, py: 1 }} tabIndex={-1} variant="h6">
-              {t('household.invitations.title')}
-            </Typography>
-            <List sx={{ bgcolor: 'background.paper', maxWidth: 360, width: '100%' }}>
-              {sortedInvitations.map((invitation) => (
-                <ListItem
-                  key={invitation.id}
-                  secondaryAction={
-                    <Stack direction="row" spacing={1}>
-                      {isInvitationProcessing &&
-                      (acceptingArgs === invitation.id || rejectingArgs === invitation.id) ? (
-                        <CircularProgress size={24} />
-                      ) : (
-                        <>
-                          <IconButton
-                            aria-label={t('household.invitations.accept')}
-                            disabled={isInvitationProcessing}
-                            edge="end"
-                            onClick={() => handleAccept(invitation.id)}
-                            sx={{ color: 'success.main' }}
-                          >
-                            <CheckIcon />
-                          </IconButton>
-                          <IconButton
-                            aria-label={t('household.invitations.reject')}
-                            disabled={isInvitationProcessing}
-                            edge="end"
-                            onClick={() => handleReject(invitation.id)}
-                            sx={{ color: 'error.main' }}
-                          >
-                            <CloseIcon />
-                          </IconButton>
-                        </>
-                      )}
-                    </Stack>
-                  }
-                >
-                  <ListItemText primary={invitation.household_name} />
-                </ListItem>
-              ))}
-            </List>
-          </Menu>
-        </>
+      {invitations && invitations.length > 0 && (
+        <InvitationsMenu
+          acceptingArgs={acceptingArgs as number}
+          invitations={invitations}
+          isProcessing={isInvitationProcessing}
+          onAccept={handleAccept}
+          onReject={handleReject}
+          rejectingArgs={rejectingArgs as number}
+        />
       )}
 
-      <Dialog fullWidth maxWidth="xs" onClose={handleCloseDialog} open={isDialogOpen}>
-        <form noValidate onSubmit={handleSubmit}>
-          <DialogTitle>{t('household.create.dialog-title')}</DialogTitle>
-          <DialogContent>
-            <TextField
-              autoFocus
-              disabled={isCreating}
-              error={!!nameError}
-              fullWidth
-              helperText={nameError}
-              label={t('household.create.name-label')}
-              margin="dense"
-              onChange={(e) => setNewHouseholdName(e.target.value)}
-              required
-              slotProps={{ htmlInput: { maxLength: 20 } }}
-              value={newHouseholdName}
-              variant="outlined"
-            />
-            <TextField
-              disabled={isCreating}
-              error={!!invitationsError}
-              fullWidth
-              helperText={invitationsError}
-              label={t('household.create.invitations-label')}
-              margin="dense"
-              onChange={(e) => setInvitationEmails(e.target.value)}
-              placeholder="email1@example.com, email2@example.com"
-              value={invitationEmails}
-              variant="outlined"
-            />
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={handleCloseDialog}>{t('household.create.cancel')}</Button>
-            <Button disabled={isCreating} type="submit" variant="contained">
-              {isCreating ? <CircularProgress size={24} /> : t('household.create.submit')}
-            </Button>
-          </DialogActions>
-        </form>
-      </Dialog>
+      <CreateHouseholdDialog
+        isCreating={isCreating}
+        onClose={handleCloseDialog}
+        onCreate={handleCreate}
+        open={isDialogOpen}
+      />
     </Box>
   );
 }

--- a/src/app/features/household/InvitationsMenu.test.tsx
+++ b/src/app/features/household/InvitationsMenu.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { vi } from 'vitest';
+import type { Invitation } from '../../../service/types';
+import TranslationsWrapper from '../../../test-util/TranslationsWrapper';
+import InvitationsMenu from './InvitationsMenu';
+
+const invitations: Invitation[] = [
+  {
+    household_id: 100,
+    household_name: 'House A',
+    id: 10,
+    invited_at: '2026-01-01T10:00:00Z',
+  },
+  {
+    household_id: 101,
+    household_name: 'House B',
+    id: 11,
+    invited_at: '2026-01-02T10:00:00Z',
+  },
+];
+
+describe('InvitationsMenu', () => {
+  const defaultProps = {
+    invitations,
+    isProcessing: false,
+    onAccept: vi.fn(),
+    onReject: vi.fn(),
+  };
+
+  const renderMenu = (props = {}) => {
+    return render(
+      <TranslationsWrapper>
+        <InvitationsMenu {...defaultProps} {...props} />
+      </TranslationsWrapper>,
+    );
+  };
+
+  it('renders indicator with correct count', () => {
+    renderMenu();
+    expect(screen.getByText('2')).toBeVisible();
+  });
+
+  it('shows the list of invitations when clicking the indicator, sorted by date', () => {
+    renderMenu();
+    fireEvent.click(screen.getByRole('button', { name: /pending invitations/i }));
+
+    const listItems = screen.getAllByRole('listitem');
+    expect(listItems).toHaveLength(2);
+    // Most recent first: House B (Jan 2) then House A (Jan 1)
+    expect(within(listItems[0]).getByText('House B')).toBeVisible();
+    expect(within(listItems[1]).getByText('House A')).toBeVisible();
+  });
+
+  it('calls onAccept when accept button is clicked', () => {
+    renderMenu();
+    fireEvent.click(screen.getByRole('button', { name: /pending invitations/i }));
+
+    const acceptButtons = screen.getAllByLabelText(/accept invitation/i);
+    fireEvent.click(acceptButtons[0]); // House B
+
+    expect(defaultProps.onAccept).toHaveBeenCalledWith(11);
+  });
+
+  it('calls onReject when reject button is clicked', () => {
+    renderMenu();
+    fireEvent.click(screen.getByRole('button', { name: /pending invitations/i }));
+
+    const rejectButtons = screen.getAllByLabelText(/reject invitation/i);
+    fireEvent.click(rejectButtons[1]); // House A
+
+    expect(defaultProps.onReject).toHaveBeenCalledWith(10);
+  });
+
+  it('shows loading indicator and disables buttons when isProcessing is true', () => {
+    renderMenu({
+      acceptingArgs: 11,
+      isProcessing: true,
+    });
+    fireEvent.click(screen.getByRole('button', { name: /pending invitations/i }));
+
+    expect(screen.getByRole('progressbar')).toBeVisible();
+    // One set of buttons should be gone (replaced by progressbar)
+    expect(screen.getAllByLabelText(/accept invitation/i)).toHaveLength(1);
+    // Remaining buttons should be disabled
+    expect(screen.getByLabelText(/accept invitation/i)).toBeDisabled();
+    expect(screen.getByLabelText(/reject invitation/i)).toBeDisabled();
+  });
+});

--- a/src/app/features/household/InvitationsMenu.tsx
+++ b/src/app/features/household/InvitationsMenu.tsx
@@ -1,0 +1,108 @@
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import EmailIcon from '@mui/icons-material/Email';
+import Badge from '@mui/material/Badge';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { type MouseEvent, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { Invitation } from '../../../service/types';
+
+interface InvitationsMenuProps {
+  acceptingArgs?: number;
+  invitations: Invitation[];
+  isProcessing: boolean;
+  onAccept: (id: number) => Promise<void>;
+  onReject: (id: number) => Promise<void>;
+  rejectingArgs?: number;
+}
+
+export default function InvitationsMenu({
+  invitations,
+  onAccept,
+  onReject,
+  isProcessing,
+  acceptingArgs,
+  rejectingArgs,
+}: InvitationsMenuProps) {
+  const { t } = useTranslation();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const handleClick = (event: MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const sortedInvitations = [...invitations].sort(
+    (a, b) => new Date(b.invited_at).getTime() - new Date(a.invited_at).getTime(),
+  );
+
+  return (
+    <>
+      <IconButton aria-label={t('household.invitations.title')} color="inherit" onClick={handleClick} sx={{ ml: 1 }}>
+        <Badge badgeContent={sortedInvitations.length} color="error">
+          <EmailIcon />
+        </Badge>
+      </IconButton>
+      <Menu anchorEl={anchorEl} onClose={handleClose} open={Boolean(anchorEl)}>
+        <Typography sx={{ px: 2, py: 1 }} tabIndex={-1} variant="h6">
+          {t('household.invitations.title')}
+        </Typography>
+        <List sx={{ bgcolor: 'background.paper', maxWidth: 360, width: '100%' }}>
+          {sortedInvitations.map((invitation) => (
+            <ListItem
+              key={invitation.id}
+              secondaryAction={
+                <Stack direction="row" spacing={1}>
+                  {isProcessing && (acceptingArgs === invitation.id || rejectingArgs === invitation.id) ? (
+                    <CircularProgress size={24} />
+                  ) : (
+                    <>
+                      <IconButton
+                        aria-label={t('household.invitations.accept')}
+                        disabled={isProcessing}
+                        edge="end"
+                        onClick={async () => {
+                          await onAccept(invitation.id);
+                          handleClose();
+                        }}
+                        sx={{ color: 'success.main' }}
+                      >
+                        <CheckIcon />
+                      </IconButton>
+                      <IconButton
+                        aria-label={t('household.invitations.reject')}
+                        disabled={isProcessing}
+                        edge="end"
+                        onClick={async () => {
+                          await onReject(invitation.id);
+                          if (sortedInvitations.length === 1) {
+                            handleClose();
+                          }
+                        }}
+                        sx={{ color: 'error.main' }}
+                      >
+                        <CloseIcon />
+                      </IconButton>
+                    </>
+                  )}
+                </Stack>
+              }
+            >
+              <ListItemText primary={invitation.household_name} />
+            </ListItem>
+          ))}
+        </List>
+      </Menu>
+    </>
+  );
+}


### PR DESCRIPTION
Refactored `HouseholdSelector` by abstracting the household creation form and invitations handling into `CreateHouseholdDialog` and `InvitationsMenu` components. Improved readability, testability, and reuse by separating concerns and reducing component complexity. Updated and added tests to ensure correct behavior.